### PR TITLE
Using text/ecmascript rather than text/jsx

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -16,7 +16,7 @@ function compileSurplus() {
         source : string,
         compiled : string;
 
-    while (scriptIn = document.querySelector("script[type='text/jsx']")) {
+    while (scriptIn = document.querySelector("script[type='text/ecmascript']")) {
         scriptIn.type += '-processed';
 
         source = scriptIn.textContent || scriptIn.innerText || scriptIn.innerHTML;


### PR DESCRIPTION
Vscode and some other IDE's are supports "text/ecmascript" usage for syntax highlighting.

![image](https://user-images.githubusercontent.com/282104/37140337-6664a412-22c2-11e8-9711-26708400e97f.png)
